### PR TITLE
Fix: unused parameter and missing field initialiser warnings

### DIFF
--- a/libplatform/io/File.cpp
+++ b/libplatform/io/File.cpp
@@ -195,7 +195,7 @@ CustomFileProvider::write( const void* buffer, Size size, Size& nout )
 }
 
 bool
-CustomFileProvider::truncate( Size size )
+CustomFileProvider::truncate( Size /*size*/ )
 {
     return true;
 }
@@ -221,7 +221,7 @@ CallbacksFileProvider::CallbacksFileProvider( const MP4IOCallbacks& callbacks, v
 }
 
 bool
-CallbacksFileProvider::open( const std::string& name, Mode mode )
+CallbacksFileProvider::open( const std::string& /*name*/, Mode /*mode*/ )
 {
     return seek(0);
 }

--- a/libutil/TrackModifier.cpp
+++ b/libutil/TrackModifier.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -174,11 +174,11 @@ TrackModifier::fromString( const string& src, uint16_t& dst )
 {
     istringstream iss( src );
     iss >> dst;
-    if( iss.rdstate() != ios::eofbit ) { 
+    if( iss.rdstate() != ios::eofbit ) {
         ostringstream oss;
         oss << "invalid value: " << src;
         throw new EXCEPTION(oss.str());
-    }   
+    }
 
     return dst;
 }
@@ -407,7 +407,7 @@ TrackModifier::toString( bool value )
 ///////////////////////////////////////////////////////////////////////////////
 
 string
-TrackModifier::toString( float value, uint8_t i, uint8_t f )
+TrackModifier::toString( float value, uint8_t /*i*/, uint8_t f )
 {
     ostringstream oss;
     oss << fixed << setprecision(f <= 8 ? 4 : 8) << value;

--- a/libutil/Utility.cpp
+++ b/libutil/Utility.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -111,11 +111,11 @@ Utility::batch( int argi )
             mp4v2::impl::log.errorf(*x);
             delete x;
         }
- 
+
         if( !_keepgoing && subResult == FAILURE )
             return FAILURE;
     }
-    
+
     return batchResult;
 }
 
@@ -408,7 +408,7 @@ Utility::printUsage( bool toerr )
     ostringstream oss;
     oss <<   "Usage: " << _name << " " << _usage
         << "\nTry -h for brief help or --help for extended help";
- 
+
     if( toerr )
         errf( "%s\n", oss.str().c_str() );
     else
@@ -477,7 +477,7 @@ Utility::process_impl()
 
     for( ;; ) {
         const uint32_t code = prog::getOption( _argc, _argv, _shortOptions.c_str(), _longOptions, NULL );
-        if( code == -1 )
+        if( code == UINT32_MAX )
             break;
 
         bool handled = false;
@@ -705,7 +705,7 @@ Utility::Group::add(
 ///////////////////////////////////////////////////////////////////////////////
 
 void
-Utility::Group::add( 
+Utility::Group::add(
     const string& lname,
     bool          lhasarg,
     uint32_t      lcode,

--- a/src/3gp.cpp
+++ b/src/3gp.cpp
@@ -34,7 +34,7 @@ namespace mp4v2 { namespace impl {
 #define _3GP_MAJOR_BRAND "3gp5"
 #define _3GP_MINOR_VERSION 0x0001
 
-void MP4File::Make3GPCompliant(const char* fileName,  char* majorBrand, uint32_t minorVersion, char** supportedBrands, uint32_t supportedBrandsCount, bool deleteIodsAtom)
+void MP4File::Make3GPCompliant(const char* /*fileName*/,  char* majorBrand, uint32_t minorVersion, char** supportedBrands, uint32_t supportedBrandsCount, bool deleteIodsAtom)
 {
     char brand[5] = "3gp5";
     char* _3gpSupportedBrands[1] = { (char*)&brand };

--- a/src/atom_root.cpp
+++ b/src/atom_root.cpp
@@ -41,7 +41,7 @@ MP4RootAtom::MP4RootAtom(MP4File &file)
     ExpectChildAtom( "moof", Optional, Many );
 }
 
-void MP4RootAtom::BeginWrite(bool use64)
+void MP4RootAtom::BeginWrite(bool /*use64*/)
 {
     m_rewrite_ftyp = (MP4FtypAtom*)FindChildAtom( "ftyp" );
     if( m_rewrite_ftyp ) {
@@ -64,7 +64,7 @@ void MP4RootAtom::Write()
     // no-op
 }
 
-void MP4RootAtom::FinishWrite(bool use64)
+void MP4RootAtom::FinishWrite(bool /*use64*/)
 {
     if( m_rewrite_ftyp ) {
         const uint64_t savepos = m_File.GetPosition();

--- a/src/bmff/typebmff.cpp
+++ b/src/bmff/typebmff.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -514,7 +514,7 @@ const bmff::EnumLanguageCode::Entry bmff::EnumLanguageCode::data[] = {
     { mp4v2::impl::bmff::ILC_ZXX,  "zxx",  "No linguistic content; Not applicable" },
     { mp4v2::impl::bmff::ILC_ZZA,  "zza",  "Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki" },
 
-    { mp4v2::impl::bmff::ILC_UNDEFINED } // must be last
+    { mp4v2::impl::bmff::ILC_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/itmf/type.cpp
+++ b/src/itmf/type.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -51,7 +51,7 @@ const itmf::EnumBasicType::Entry itmf::EnumBasicType::data[] = {
     { mp4v2::impl::itmf::BT_UPC,       "upc",       "UPC" },
     { mp4v2::impl::itmf::BT_BMP,       "bmp",       "BMP" },
 
-    { mp4v2::impl::itmf::BT_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::BT_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ const itmf::EnumGenreType::Entry itmf::EnumGenreType::data[] = {
     { mp4v2::impl::itmf::GENRE_DANCE_HALL,        "dancehall",         "Dance Hall" },
     { mp4v2::impl::itmf::GENRE_NONE,              "none",              "none" },
 
-    { mp4v2::impl::itmf::GENRE_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::GENRE_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -203,7 +203,7 @@ const itmf::EnumStikType::Entry itmf::EnumStikType::data[] = {
     { mp4v2::impl::itmf::STIK_BOOKLET,      "booklet",     "Booklet" },
     { mp4v2::impl::itmf::STIK_RINGTONE,     "ringtone",    "Ringtone" },
 
-    { mp4v2::impl::itmf::STIK_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::STIK_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -213,7 +213,7 @@ const itmf::EnumAccountType::Entry itmf::EnumAccountType::data[] = {
     { mp4v2::impl::itmf::AT_ITUNES,  "itunes",   "iTunes" },
     { mp4v2::impl::itmf::AT_AOL,     "aol",      "AOL" },
 
-    { mp4v2::impl::itmf::AT_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::AT_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -243,7 +243,7 @@ const itmf::EnumCountryCode::Entry itmf::EnumCountryCode::data[] = {
     { mp4v2::impl::itmf::CC_NZL,  "nzl",   "New Zealand" },
     { mp4v2::impl::itmf::CC_JPN,  "jpn",   "Japan" },
 
-    { mp4v2::impl::itmf::CC_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::CC_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -255,7 +255,7 @@ const itmf::EnumContentRating::Entry itmf::EnumContentRating::data[] = {
     { mp4v2::impl::itmf::CR_CLEAN,        "clean",      "Clean" },
     { mp4v2::impl::itmf::CR_EXPLICIT_OLD, "explicit",   "Explicit" },
 
-    { mp4v2::impl::itmf::CR_UNDEFINED } // must be last
+    { mp4v2::impl::itmf::CR_UNDEFINED, nullptr, nullptr } // must be last
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -287,7 +287,7 @@ namespace {
         { BT_GIF,  "GIF89a" },
         { BT_JPEG, "\xff\xd8\xff" },
         { BT_PNG,  "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" },
-        { BT_UNDEFINED } // must be last
+        { BT_UNDEFINED, nullptr } // must be last
     };
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is David Byron.
 //  Portions created by David Byron are Copyright (C) 2009, 2010, 2011.
 //  All Rights Reserved.
@@ -233,7 +233,7 @@ Log::verbose4f( const char* format,
  */
 void
 Log::dump ( uint8_t       indent,
-            MP4LogLevel   verbosity_,
+            MP4LogLevel   /*verbosity_*/,
             const char*   format, ... )
 {
     va_list     ap;
@@ -296,7 +296,7 @@ Log::vdump( uint8_t     indent,
         return;
     }
 
-    // No callback set so log to standard out.  
+    // No callback set so log to standard out.
     if (indent > 0)
     {
         ::fprintf(stdout,"%*c",indent,' ');
@@ -365,7 +365,7 @@ Log::vprintf( MP4LogLevel       verbosity_,
         return;
     }
 
-    // No callback set so log to standard out.  
+    // No callback set so log to standard out.
     ::vfprintf(stdout,format,ap);
     ::fprintf(stdout,"\n");
 }
@@ -531,4 +531,3 @@ void MP4LogSetLevel( MP4LogLevel verbosity )
         mp4v2::impl::log.errorf( "%s: failed", __FUNCTION__ );
     }
 }
-

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -236,7 +236,8 @@ MP4FileHandle MP4CreateCallbacksEx (const MP4IOCallbacks* callbacks,
 
 ///////////////////////////////////////////////////////////////////////////////
 
-MP4FileHandle MP4CreateProvider(const char *fileName, const MP4FileProvider* fileProvider, uint32_t verbosity, uint32_t flags)
+MP4FileHandle MP4CreateProvider(const char *fileName, const MP4FileProvider* fileProvider,
+    uint32_t /*verbosity*/, uint32_t flags)
 {
     MP4File *pFile = NULL;
     try {
@@ -253,7 +254,7 @@ MP4FileHandle MP4CreateProvider(const char *fileName, const MP4FileProvider* fil
 }
 
 MP4FileHandle MP4Modify(const char* fileName,
-                        uint32_t flags)
+                        uint32_t /*flags*/)
 {
     if (!fileName)
         return MP4_INVALID_FILE_HANDLE;
@@ -283,7 +284,7 @@ MP4FileHandle MP4Modify(const char* fileName,
 
 MP4FileHandle MP4ModifyCallbacks(const MP4IOCallbacks* callbacks,
                                  void* handle,
-                                 uint32_t flags)
+                                 uint32_t /*flags*/)
 {
     if (!callbacks)
         return MP4_INVALID_FILE_HANDLE;
@@ -3262,12 +3263,12 @@ MP4FileHandle MP4ModifyCallbacks(const MP4IOCallbacks* callbacks,
     }
 
     bool MP4ReferenceSample(
-        MP4FileHandle srcFile,
-        MP4TrackId srcTrackId,
-        MP4SampleId srcSampleId,
-        MP4FileHandle dstFile,
-        MP4TrackId dstTrackId,
-        MP4Duration dstSampleDuration)
+        MP4FileHandle /*srcFile*/,
+        MP4TrackId /*srcTrackId*/,
+        MP4SampleId /*srcSampleId*/,
+        MP4FileHandle /*dstFile*/,
+        MP4TrackId /*dstTrackId*/,
+        MP4Duration /*dstSampleDuration*/)
     {
         // LATER Not yet implemented
         return false;
@@ -4601,7 +4602,7 @@ bool MP4SetTrackLanguage(
 
     try {
         return ((MP4File*)hFile)->SetTrackLanguage( trackId, code );
-    }   
+    }
     catch( Exception* x ) {
         mp4v2::impl::log.errorf(*x);
         delete x;
@@ -4665,7 +4666,7 @@ bool MP4SetTrackName(
 
 bool MP4GetTrackDurationPerChunk(
     MP4FileHandle hFile,
-    MP4TrackId    trackId, 
+    MP4TrackId    trackId,
     MP4Duration*  duration )
 {
     if( !MP4_IS_VALID_FILE_HANDLE( hFile ))

--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -1125,7 +1125,7 @@ void MP4File::AddTrackToIod(MP4TrackId trackId)
     pIdProperty->SetValue(trackId);
 }
 
-void MP4File::RemoveTrackFromIod(MP4TrackId trackId, bool shallHaveIods)
+void MP4File::RemoveTrackFromIod(MP4TrackId trackId, bool /*shallHaveIods*/)
 {
     MP4DescriptorProperty* pDescriptorProperty = NULL;
     if (!m_pRootAtom->FindProperty("moov.iods.esIds",(MP4Property**)&pDescriptorProperty)
@@ -2132,7 +2132,7 @@ void MP4File::AddH264PictureParameterSet (MP4TrackId trackId,
                 uint32_t seqlen;
                 pUnit->GetValue(&seq, &seqlen, index);
                 if (memcmp(seq, pPict, pictLen) == 0) {
-                    log.verbose1f("\"%s\": picture matches %d", 
+                    log.verbose1f("\"%s\": picture matches %d",
                                   GetFilename().c_str(), index);
                     free(seq);
                     return;
@@ -3166,7 +3166,7 @@ void MP4File::WriteSample(
 
 void MP4File::WriteSampleDependency(
     MP4TrackId     trackId,
-    const uint8_t* pBytes, 
+    const uint8_t* pBytes,
     uint32_t       numBytes,
     MP4Duration    duration,
     MP4Duration    renderingOffset,
@@ -3328,7 +3328,7 @@ bool MP4File::SetTrackLanguage( MP4TrackId trackId, const char* code )
     return true;
 }
 
-    
+
 bool MP4File::GetTrackName( MP4TrackId trackId, char** name )
 {
     unsigned char *val = NULL;
@@ -3371,7 +3371,7 @@ bool MP4File::SetTrackName( MP4TrackId trackId, const char* name )
     {
         if (!AddDescendantAtoms(MakeTrackName(trackId, NULL), "udta.name"))
             return false;
-        
+
         pMetaAtom = m_pRootAtom->FindAtom(atomstring);
         if (pMetaAtom == NULL) return false;
     }
@@ -3550,7 +3550,7 @@ const char *MP4File::GetTrackMediaDataName (MP4TrackId trackId)
        return NULL;
 
     if (pAtom->GetNumberOfChildAtoms() != 1) {
-        log.errorf("%s: \"%s\": track %d has more than 1 child atoms in stsd", 
+        log.errorf("%s: \"%s\": track %d has more than 1 child atoms in stsd",
                    __FUNCTION__, GetFilename().c_str(), trackId);
         return NULL;
     }
@@ -4452,7 +4452,7 @@ void MP4File::EncAndCopySample(
 
     //if( ismacrypEncryptSampleAddHeader( ismaCryptSId, numBytes, pBytes, &encSampleLength, &encSampleData ) != 0)
     if( encfcnp( encfcnparam1, numBytes, pBytes, &encSampleLength, &encSampleData ) != 0 )
-        log.errorf("%s(%s,%s) Can't encrypt the sample and add its header %u", 
+        log.errorf("%s(%s,%s) Can't encrypt the sample and add its header %u",
                    __FUNCTION__, srcFile->GetFilename().c_str(), dstFile->GetFilename().c_str(), srcSampleId );
 
     if( hasDependencyFlags ) {

--- a/src/mp4property.cpp
+++ b/src/mp4property.cpp
@@ -35,14 +35,14 @@ MP4Property::MP4Property(MP4Atom& parentAtom, const char* name)
 }
 
 bool MP4Property::FindProperty(const char* name,
-                               MP4Property** ppProperty, uint32_t* pIndex)
+                               MP4Property** ppProperty, uint32_t* /*pIndex*/)
 {
     if (name == NULL) {
         return false;
     }
 
     if (!strcasecmp(m_name, name)) {
-        log.verbose1f("\"%s\": FindProperty: matched %s", 
+        log.verbose1f("\"%s\": FindProperty: matched %s",
                       m_parentAtom.GetFile().GetFilename().c_str(), name);
         *ppProperty = this;
         return true;
@@ -140,7 +140,7 @@ void MP4IntegerProperty::DeleteValue(uint32_t index)
     }
 }
 
-void MP4IntegerProperty::IncrementValue(int32_t increment, uint32_t index)
+void MP4IntegerProperty::IncrementValue(int32_t increment, uint32_t /*index*/)
 {
     SetValue(GetValue() + increment);
 }
@@ -747,8 +747,8 @@ bool MP4TableProperty::FindProperty(const char *name,
             *pIndex = index;
         }
     }
-    
-    log.verbose1f("\"%s\": FindProperty: matched %s", 
+
+    log.verbose1f("\"%s\": FindProperty: matched %s",
                   m_parentAtom.GetFile().GetFilename().c_str(), name);
 
     // get name of table property
@@ -1085,7 +1085,7 @@ MP4LanguageCodeProperty::MP4LanguageCodeProperty( MP4Atom& parentAtom, const cha
 }
 
 void
-MP4LanguageCodeProperty::Dump( uint8_t indent, bool dumpImplicits, uint32_t index )
+MP4LanguageCodeProperty::Dump( uint8_t indent, bool /*dumpImplicits*/, uint32_t /*index*/ )
 {
     uint16_t data = 0;
 
@@ -1121,7 +1121,7 @@ MP4LanguageCodeProperty::GetValue()
 }
 
 void
-MP4LanguageCodeProperty::Read( MP4File& file, uint32_t index )
+MP4LanguageCodeProperty::Read( MP4File& file, uint32_t /*index*/ )
 {
     uint16_t data = file.ReadBits( 16 );
 
@@ -1134,7 +1134,7 @@ MP4LanguageCodeProperty::Read( MP4File& file, uint32_t index )
 }
 
 void
-MP4LanguageCodeProperty::SetCount( uint32_t count )
+MP4LanguageCodeProperty::SetCount( uint32_t /*count*/ )
 {
     // do nothing; count is always 1
 }
@@ -1146,7 +1146,7 @@ MP4LanguageCodeProperty::SetValue( bmff::LanguageCode value )
 }
 
 void
-MP4LanguageCodeProperty::Write( MP4File& file, uint32_t index )
+MP4LanguageCodeProperty::Write( MP4File& file, uint32_t /*index*/ )
 {
     uint16_t data = 0;
 
@@ -1170,7 +1170,7 @@ MP4BasicTypeProperty::MP4BasicTypeProperty( MP4Atom& parentAtom, const char* nam
 }
 
 void
-MP4BasicTypeProperty::Dump( uint8_t indent, bool dumpImplicits, uint32_t index )
+MP4BasicTypeProperty::Dump( uint8_t indent, bool /*dumpImplicits*/, uint32_t /*index*/ )
 {
     log.dump(indent, MP4_LOG_VERBOSE1, "\"%s\": %s = %s (0x%02x)",
              m_parentAtom.GetFile().GetFilename().c_str(), m_name,
@@ -1196,13 +1196,13 @@ MP4BasicTypeProperty::GetValue()
 }
 
 void
-MP4BasicTypeProperty::Read( MP4File& file, uint32_t index )
+MP4BasicTypeProperty::Read( MP4File& file, uint32_t /*index*/ )
 {
     SetValue( static_cast<itmf::BasicType>( file.ReadBits( 8 )));
 }
 
 void
-MP4BasicTypeProperty::SetCount( uint32_t count )
+MP4BasicTypeProperty::SetCount( uint32_t /*count*/ )
 {
     // do nothing; count is always 1
 }
@@ -1214,7 +1214,7 @@ MP4BasicTypeProperty::SetValue( itmf::BasicType value )
 }
 
 void
-MP4BasicTypeProperty::Write( MP4File& file, uint32_t index )
+MP4BasicTypeProperty::Write( MP4File& file, uint32_t /*index*/ )
 {
     file.WriteBits( _value, 8 );
 }

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -277,7 +277,7 @@ void MP4Track::ReadSample(
     MP4Duration*  pDuration,
     MP4Duration*  pRenderingOffset,
     bool*         pIsSyncSample,
-    bool*         hasDependencyFlags, 
+    bool*         hasDependencyFlags,
     uint32_t*     dependencyFlags )
 {
     if( sampleId == MP4_INVALID_SAMPLE_ID )
@@ -433,7 +433,7 @@ void MP4Track::WriteSample(
         duration = GetFixedSampleDuration();
     }
 
-    log.verbose3f("\"%s\": duration %" PRIu64, GetFile().GetFilename().c_str(), 
+    log.verbose3f("\"%s\": duration %" PRIu64, GetFile().GetFilename().c_str(),
                   duration);
 
     if ((m_isAmr == AMR_TRUE) &&
@@ -445,9 +445,9 @@ void MP4Track::WriteSample(
     // append sample bytes to chunk buffer
     if( m_sizeOfDataInChunkBuffer + numBytes > m_chunkBufferSize ) {
         m_pChunkBuffer = (uint8_t*)MP4Realloc(m_pChunkBuffer, m_chunkBufferSize + numBytes);
-        if (m_pChunkBuffer == NULL) 
-            return;	
-        
+        if (m_pChunkBuffer == NULL)
+            return;
+
         m_chunkBufferSize += numBytes;
     }
 
@@ -500,7 +500,7 @@ void MP4Track::WriteChunkBuffer()
     m_File.WriteBytes(m_pChunkBuffer, m_sizeOfDataInChunkBuffer);
 
     log.verbose3f("\"%s\": WriteChunk: track %u offset 0x%" PRIx64 " size %u (0x%x) numSamples %u",
-                  GetFile().GetFilename().c_str(), 
+                  GetFile().GetFilename().c_str(),
                   m_trackId, chunkOffset, m_sizeOfDataInChunkBuffer,
                   m_sizeOfDataInChunkBuffer, m_chunkSamples);
 
@@ -612,7 +612,7 @@ void MP4Track::FinishSdtp()
     }
 }
 
-bool MP4Track::IsChunkFull(MP4SampleId sampleId)
+bool MP4Track::IsChunkFull(MP4SampleId /*sampleId*/)
 {
     if (m_samplesPerChunk) {
         return m_chunkSamples >= m_samplesPerChunk;
@@ -941,7 +941,7 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
 
         const char* url = pLocationProperty->GetValue();
 
-        log.verbose3f("\"%s\": dref url = %s", GetFile().GetFilename().c_str(), 
+        log.verbose3f("\"%s\": dref url = %s", GetFile().GetFilename().c_str(),
                       url);
 
         file = (File*)-1;

--- a/src/qtff/ColorParameterBox.cpp
+++ b/src/qtff/ColorParameterBox.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -30,7 +30,7 @@ namespace mp4v2 { namespace impl { namespace qtff {
 namespace {
     const string BOX_CODE = "colr";
 
-    bool findColorParameterBox( MP4FileHandle file, MP4Atom& coding, MP4Atom*& colr );
+    bool findColorParameterBox(MP4Atom& coding, MP4Atom*& colr );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -47,7 +47,7 @@ ColorParameterBox::add( MP4FileHandle file, uint16_t trackIndex, const Item& ite
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
-    if( !findColorParameterBox( file, *coding, colr ))
+    if( !findColorParameterBox( *coding, colr ))
         throw new EXCEPTION("colr-box already exists");
 
     colr = MP4Atom::CreateAtom( *((MP4File *)file), coding, BOX_CODE.c_str() );
@@ -95,7 +95,7 @@ ColorParameterBox::get( MP4FileHandle file, uint16_t trackIndex, Item& item )
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
-    if( findColorParameterBox( file, *coding, colr ))
+    if( findColorParameterBox( *coding, colr ))
         throw new EXCEPTION("colr-box not found");
 
     MP4Integer16Property* primariesIndex;
@@ -174,7 +174,7 @@ ColorParameterBox::remove( MP4FileHandle file, uint16_t trackIndex )
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
-    if( findColorParameterBox( file, *coding, colr ))
+    if( findColorParameterBox( *coding, colr ))
         throw new EXCEPTION("colr-box not found");
 
     coding->DeleteChildAtom( colr );
@@ -202,7 +202,7 @@ ColorParameterBox::set( MP4FileHandle file, uint16_t trackIndex, const Item& ite
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
-    if( findColorParameterBox( file, *coding, colr ))
+    if( findColorParameterBox( *coding, colr ))
         throw new EXCEPTION("colr-box not found");
 
     MP4Integer16Property* primariesIndex;
@@ -309,7 +309,7 @@ namespace {
 ///////////////////////////////////////////////////////////////////////////////
 
 bool
-findColorParameterBox( MP4FileHandle file, MP4Atom& coding, MP4Atom*& colr )
+findColorParameterBox(MP4Atom& coding, MP4Atom*& colr )
 {
     colr = NULL;
 

--- a/src/qtff/PictureAspectRatioBox.cpp
+++ b/src/qtff/PictureAspectRatioBox.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Kona Blend.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  All Rights Reserved.
@@ -30,7 +30,7 @@ namespace mp4v2 { namespace impl { namespace qtff {
 namespace {
     const string BOX_CODE = "pasp";
 
-    bool findPictureAspectRatioBox( MP4FileHandle file, MP4Atom& coding, MP4Atom*& pasp );
+    bool findPictureAspectRatioBox(MP4Atom& coding, MP4Atom*& pasp );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -47,7 +47,7 @@ PictureAspectRatioBox::add( MP4FileHandle file, uint16_t trackIndex, const Item&
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
-    if( !findPictureAspectRatioBox( file, *coding, pasp ))
+    if( !findPictureAspectRatioBox( *coding, pasp ))
         throw new EXCEPTION("pasp-box already exists");
 
     pasp = MP4Atom::CreateAtom( *((MP4File *)file), coding, BOX_CODE.c_str() );
@@ -87,7 +87,7 @@ PictureAspectRatioBox::get( MP4FileHandle file, uint16_t trackIndex, Item& item 
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
-    if( findPictureAspectRatioBox( file, *coding, pasp ))
+    if( findPictureAspectRatioBox( *coding, pasp ))
         throw new EXCEPTION("pasp-box not found");
 
     MP4Integer16Property* hSpacing;
@@ -162,7 +162,7 @@ PictureAspectRatioBox::remove( MP4FileHandle file, uint16_t trackIndex )
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
-    if( findPictureAspectRatioBox( file, *coding, pasp ))
+    if( findPictureAspectRatioBox( *coding, pasp ))
         throw new EXCEPTION("pasp-box not found");
 
     coding->DeleteChildAtom( pasp );
@@ -190,7 +190,7 @@ PictureAspectRatioBox::set( MP4FileHandle file, uint16_t trackIndex, const Item&
         throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
-    if( findPictureAspectRatioBox( file, *coding, pasp ))
+    if( findPictureAspectRatioBox( *coding, pasp ))
         throw new EXCEPTION("pasp-box not found");
 
     MP4Integer16Property* hSpacing;
@@ -289,7 +289,7 @@ namespace {
 ///////////////////////////////////////////////////////////////////////////////
 
 bool
-findPictureAspectRatioBox( MP4FileHandle file, MP4Atom& coding, MP4Atom*& pasp )
+findPictureAspectRatioBox(MP4Atom& coding, MP4Atom*& pasp )
 {
     pasp = NULL;
 

--- a/src/rtphint.cpp
+++ b/src/rtphint.cpp
@@ -640,7 +640,7 @@ void MP4RtpHintTrack::WriteHint(MP4Duration duration, bool isSyncSample)
     m_pWriteHint = NULL;
 }
 
-void MP4RtpHintTrack::FinishWrite(uint32_t option)
+void MP4RtpHintTrack::FinishWrite(uint32_t /*option*/)
 {
     if (m_writeHintId != MP4_INVALID_SAMPLE_ID) {
         m_pMaxPdu->SetValue(m_pPmax->GetValue());

--- a/src/rtphint.h
+++ b/src/rtphint.h
@@ -45,7 +45,7 @@ public:
 
     MP4Track* FindTrackFromRefIndex(uint8_t refIndex);
 
-    virtual void WriteEmbeddedData(MP4File& file, uint64_t startPos) {
+    virtual void WriteEmbeddedData(MP4File& /*file*/, uint64_t /*startPos*/) {
         // default is no-op
     }
 
@@ -63,7 +63,7 @@ public:
         return 0;
     }
 
-    void GetData(uint8_t* pDest) {
+    void GetData(uint8_t* /*pDest*/) {
         // no-op
     }
 };


### PR DESCRIPTION
In this PR we address the myriad of warnings caused by unused named parameters and missing field initialisers, which is causing considerable noise for libAudio's CI.

These patches should reduce the current warning list for the library down to 0.