### PR TITLE
Fix: sprintf usage

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -418,15 +418,15 @@ Log::hexDump( uint8_t           indent,
     if (format[0] || indent)
     {
         desc = (char *)MP4Calloc(256 + indent);
-        sprintf(desc,"%*c",indent,' ');
-        va_start(ap,format);
-        vsnprintf(desc + indent,255,format,ap);
+        snprintf(desc, 256 + indent, "%*c", indent, ' ');
+        va_start(ap, format);
+        vsnprintf(desc + indent, 255, format, ap);
         va_end(ap);
     }
 
     // From here we can use the C++ standard lib classes and
     // build a string for each line
-    for (uint32_t i = 0;(i < numBytes);i += 16)
+    for (uint32_t i = 0; i < numBytes; i += 16)
     {
         // ios_base::ate means at end.  With out this desc
         // gets overwritten with each << operation
@@ -439,11 +439,11 @@ Log::hexDump( uint8_t           indent,
         oneLine << ':' << hex << setw(8) << setfill('0') <<
             std::right << i << setw(0) << setfill(' ') << ": ";
 
-        uint32_t curlen = min((uint32_t)16,numBytes - i);
+        uint32_t curlen = min((uint32_t)16, numBytes - i);
         const uint8_t *b = pBytes + i;
         uint32_t j;
 
-        for (j = 0;(j < curlen);j++)
+        for (j = 0; j < curlen; j++)
         {
             oneLine << hex << setw(2) << setfill('0') << right << static_cast<uint32_t>(b[j]);
             oneLine << setw(0) << setfill(' ') << ' ';
@@ -455,7 +455,7 @@ Log::hexDump( uint8_t           indent,
         }
 
         b = pBytes + i;
-        for (j = 0;(j < curlen);j++)
+        for (j = 0; j < curlen; j++)
         {
             if (isprint(static_cast<int>(b[j])))
             {
@@ -475,7 +475,7 @@ Log::hexDump( uint8_t           indent,
         // double-check the verbosity and the callback
         // function pointer, but that seems OK (13-feb-09,
         // dbyron)
-        this->printf(verbosity_,"%s",oneLine.str().c_str());
+        this->printf(verbosity_, "%s", oneLine.str().c_str());
     }
 
     if (desc)

--- a/src/mp4info.cpp
+++ b/src/mp4info.cpp
@@ -444,7 +444,8 @@ static char* PrintVideoInfo(
 
     // type duration avgBitrate frameSize frameRate
     if (foundTypeName) {
-        sprintf(sInfo,
+        snprintf(sInfo,
+                256,
                 "%u\tvideo\t%s%s, %.3f secs, %u kbps, %ux%u @ %f fps\n",
                 trackId,
                 MP4IsIsmaCrypMediaTrack(mp4File, trackId) ? "encv - " : "",
@@ -456,7 +457,8 @@ static char* PrintVideoInfo(
                 fps
                );
     } else {
-        sprintf(sInfo,
+        snprintf(sInfo,
+                256,
                 "%u\tvideo\t%s(%u), %.3f secs, %u kbps, %ux%u @ %f fps\n",
                 trackId,
                 typeName,

--- a/test/urltrack.cpp
+++ b/test/urltrack.cpp
@@ -3,19 +3,19 @@
  * License Version 1.1 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of
  * the License at http://www.mozilla.org/MPL/
- * 
+ *
  * Software distributed under the License is distributed on an "AS
  * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
  * implied. See the License for the specific language governing
  * rights and limitations under the License.
- * 
+ *
  * The Original Code is MPEG4IP.
- * 
+ *
  * The Initial Developer of the Original Code is Cisco Systems Inc.
  * Portions created by Cisco Systems Inc. are
  * Copyright (C) Cisco Systems Inc. 2001.  All Rights Reserved.
- * 
- * Contributor(s): 
+ *
+ * Contributor(s):
  *        Dave Mackie        dmackie@cisco.com
  */
 
@@ -34,7 +34,7 @@ main(int argc, char** argv)
     if (!mp4File)
         return 1;
 
-    MP4TrackId urlTrackId = 
+    MP4TrackId urlTrackId =
 #if 0
     MP4AddTrack(mp4File, "URLF");
 #else
@@ -48,7 +48,7 @@ main(int argc, char** argv)
     for (i = 1; i <= 5; i++) {
         sprintf(url, "http://server.com/foo/bar%u.html", i);
 
-        MP4WriteSample(mp4File, urlTrackId, 
+        MP4WriteSample(mp4File, urlTrackId,
             (uint8_t*)url, strlen(url) + 1, (MP4Duration)i);
     }
 
@@ -63,7 +63,7 @@ main(int argc, char** argv)
     urlTrackId = MP4FindTrackId(mp4File, 0, MP4_CNTL_TRACK_TYPE);
 #endif
     printf("urlTrackId %d\n", urlTrackId);
-    
+
     for (i = 1; i <= 5; i++) {
         uint8_t* pSample = NULL;
         uint32_t sampleSize = 0;
@@ -74,7 +74,7 @@ main(int argc, char** argv)
             &pSample, &sampleSize, NULL, &duration);
 
         if (rc) {
-            printf("Sample %i duration %llu: %s\n", 
+            printf("Sample %i duration %llu: %s\n",
                 i, duration, pSample);
             MP4Free(pSample);
         } else {
@@ -86,4 +86,3 @@ main(int argc, char** argv)
 
     return 0;
 }
-

--- a/test/urltrack.cpp
+++ b/test/urltrack.cpp
@@ -20,9 +20,10 @@
  */
 
 #include <mp4v2/mp4v2.h>
-#include <string.h>
+#include <cstring>
+#include <algorithm>
 
-main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <file>\n", argv[0]);
@@ -43,13 +44,19 @@ main(int argc, char** argv)
     printf("urlTrackId %d\n", urlTrackId);
 
     uint8_t i;
-    char url[128];
 
     for (i = 1; i <= 5; i++) {
-        snprintf(url, 128, "http://server.com/foo/bar%u.html", i);
+        char url[128] = {};
+        int result = snprintf(url, 128U, "http://server.com/foo/bar%u.html", i);
+        if (result < 0) {
+            fprintf(stderr, "Failure while constructing URL %u\n", i);
+            MP4Close(mp4File);
+            return 1;
+        }
+        const size_t length = std::min<size_t>(result + 1U, 128U);
 
         MP4WriteSample(mp4File, urlTrackId,
-            (uint8_t*)url, strlen(url) + 1, (MP4Duration)i);
+            (uint8_t *)url, length, (MP4Duration)i);
     }
 
     MP4Close(mp4File);

--- a/test/urltrack.cpp
+++ b/test/urltrack.cpp
@@ -46,7 +46,7 @@ main(int argc, char** argv)
     char url[128];
 
     for (i = 1; i <= 5; i++) {
-        sprintf(url, "http://server.com/foo/bar%u.html", i);
+        snprintf(url, 128, "http://server.com/foo/bar%u.html", i);
 
         MP4WriteSample(mp4File, urlTrackId,
             (uint8_t*)url, strlen(url) + 1, (MP4Duration)i);

--- a/util/mp4chaps.cpp
+++ b/util/mp4chaps.cpp
@@ -9,9 +9,9 @@
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 //  License for the specific language governing rights and limitations
 //  under the License.
-// 
+//
 //  The Original Code is MP4v2.
-// 
+//
 //  The Initial Developer of the Original Code is Ullrich Pollaehne.
 //  Portions created by Kona Blend are Copyright (C) 2008.
 //  Portions created by David Byron are Copyright (C) 2010.
@@ -162,7 +162,7 @@ ChapterUtility::ChapterUtility( int argc, char** argv )
 
 /** Action for listing chapters from <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -215,7 +215,7 @@ ChapterUtility::actionList( JobContext& job )
 
 /** Action for converting chapters in <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -270,7 +270,7 @@ ChapterUtility::actionConvert( JobContext& job )
 
 /** Action for setting chapters every n second in <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -333,7 +333,7 @@ ChapterUtility::actionEvery( JobContext& job )
 
 /** Action for exporting chapters from the <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -486,7 +486,7 @@ ChapterUtility::actionExport( JobContext& job )
 
 /** Action for importing chapters into the <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -613,7 +613,7 @@ ChapterUtility::actionImport( JobContext& job )
 
 /** Action for removing chapters from the <b>job.file</b>
  *
- *  
+ *
  *  @param job the job to process
  *  @return mp4v2::util::SUCCESS if successful, mp4v2::util::FAILURE otherwise
  */
@@ -1100,7 +1100,7 @@ ChapterUtility::parseChapterFile( const string& filename, vector<MP4Chapter_t>& 
 
                     currentChapter = chNr;
                 }
-                formatState = FMT_STATE_TITLE_LINE == formatState ? FMT_STATE_FINISH 
+                formatState = FMT_STATE_TITLE_LINE == formatState ? FMT_STATE_FINISH
                                                                   : FMT_STATE_TIME_LINE;
 
                 timeStart = equalsPos + 1;

--- a/util/mp4chaps.cpp
+++ b/util/mp4chaps.cpp
@@ -311,7 +311,7 @@ ChapterUtility::actionEvery( JobContext& job )
     {
         MP4Chapter_t chap;
         chap.duration = refTrackDuration.duration > chapterDuration.duration ? chapterDuration.duration : refTrackDuration.duration;
-        sprintf(chap.title, "Chapter %zu", chapters.size()+1);
+        snprintf(chap.title, MP4V2_CHAPTER_TITLE_MAX + 1U, "Chapter %zu", chapters.size() + 1U);
 
         chapters.push_back( chap );
         refTrackDuration -= chapterDuration;


### PR DESCRIPTION
During a recent build on macOS, it was pointed out to us by amyspark that there were some instances of sprintf() usage in the code base which should be trivially fixed and converted over to snprintf() usage for improved security and safety.

This PR addresses just that, converting all remaining sprintf() usage over.